### PR TITLE
feat: Add frame-level E2EE video decryption for publisher HLS agent

### DIFF
--- a/examples/publisher-hls-agent/e2ee.go
+++ b/examples/publisher-hls-agent/e2ee.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"log"
@@ -12,14 +13,15 @@ import (
 	lksdk "github.com/livekit/server-sdk-go/v2"
 )
 
-// E2EE encryption constants (matching LiveKit client SDK)
+// H264 NAL unit types for RTP packet classification
 const (
-	// ivLength is the length of the initialization vector in bytes
-	ivLength = 12
-	// unencryptedVideoBytes is the number of leading bytes in H264 frames that remain unencrypted
-	// This typically corresponds to the NAL unit header (1 byte for type + 1 byte for start code indicator)
-	// Based on LiveKit SFrame implementation, this value may vary but we use 1 for compatibility
-	unencryptedVideoBytes = 1
+	// Single NAL unit types (1-23) - packet contains one complete NAL unit
+	nalTypeSingleMin = 1
+	nalTypeSingleMax = 23
+	// STAP-A (24) - Single-Time Aggregation Packet type A
+	nalTypeSTAPA = 24
+	// FU-A (28) - Fragmentation Unit type A
+	nalTypeFUA = 28
 )
 
 var (
@@ -70,20 +72,36 @@ type E2EEContext struct {
 //
 // Returns an error if key derivation fails.
 func NewE2EEContext(passphrase string, sifTrailer []byte) (*E2EEContext, error) {
-	key, err := lksdk.DeriveKeyFromString(passphrase)
+	// Decode base64 encryption key to raw bytes (URL encoding without padding)
+	keyBytes, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(passphrase)
 	if err != nil {
-		return nil, fmt.Errorf("failed to derive E2EE key: %w", err)
+		return nil, fmt.Errorf("decode encryption key: %w", err)
 	}
 
-	cipherBlock, err := aes.NewCipher(key)
+	// Validate key size (should be 16 bytes for AES-128-GCM as per LiveKit E2EE spec)
+	if len(keyBytes) != 16 {
+		return nil, fmt.Errorf("invalid key size: expected 16 bytes for AES-128-GCM, got %d", len(keyBytes))
+	}
+
+	// Derive encryption key using HKDF (same as LiveKit client SDK)
+	// This matches the key derivation in livekit-client's createKeyMaterialFromBuffer + deriveKeys
+	// Using salt "LKFrameEncryptionKey", info 128 bytes, SHA-256 → 16-byte output
+	derivedKey, err := lksdk.DeriveKeyFromBytes(keyBytes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create AES cipher: %w", err)
+		return nil, fmt.Errorf("derive encryption key: %w", err)
+	}
+
+	// Create AES cipher cipherBlock from HKDF-derived key
+	// This will be used by lksdk.DecryptGCMAudioSampleCustomCipher for decryption
+	cipherBlock, err := aes.NewCipher(derivedKey)
+	if err != nil {
+		return nil, fmt.Errorf("create AES cipher: %w", err)
 	}
 
 	log.Printf("[e2ee] initialized E2EE context (sifTrailer len=%d)", len(sifTrailer))
 
 	return &E2EEContext{
-		key:         key,
+		key:         derivedKey,
 		sifTrailer:  sifTrailer,
 		cipherBlock: cipherBlock,
 		enabled:     true,
@@ -144,8 +162,10 @@ func (e *E2EEContext) DecryptAudio(payload []byte) ([]byte, error) {
 // DecryptVideo decrypts an E2EE-encrypted video RTP payload.
 //
 // Video frames use the same AES-GCM encryption format as audio, but with
-// potentially different unencrypted header bytes depending on the codec.
-// For H264, typically 1-2 bytes of NAL unit header remain unencrypted.
+// different unencrypted header bytes depending on the H264 packet type:
+//   - Single NAL (types 1-23): 1 byte unencrypted
+//   - FU-A (type 28): 2 bytes unencrypted
+//   - STAP-A (type 24): 1 byte unencrypted
 //
 // Encrypted payload format (same as LiveKit client SDK):
 //
@@ -154,9 +174,9 @@ func (e *E2EEContext) DecryptAudio(payload []byte) ([]byte, error) {
 //	+---------+-------------------------+---------+----+
 //
 // Where:
-//   - frameHdr: Unencrypted frame header (used for authentication)
-//   - encrypted payload: AES-GCM encrypted video data
-//   - IV: Initialization vector (12 bytes typical)
+//   - frameHdr: Unencrypted frame header (used for AAD authentication)
+//   - encrypted payload: AES-GCM encrypted video data (may need RBSP unescaping)
+//   - IV: Initialization vector (typically 12 bytes)
 //   - len: IV length (1 byte)
 //   - KID: Key ID (1 byte, ignored - key provided externally)
 //
@@ -183,8 +203,11 @@ func (e *E2EEContext) DecryptVideo(payload []byte) ([]byte, error) {
 		}
 	}
 
-	// Minimum payload size: frameHeader + ciphertext(16 byte auth tag min) + IV + ivLength + KID
-	minSize := unencryptedVideoBytes + 16 + ivLength + 2
+	// Determine unencrypted bytes based on H264 packet type
+	unencryptedBytes := getH264UnencryptedBytes(payload)
+
+	// Minimum payload size: frameHeader + ciphertext(16 byte auth tag min) + IV + trailer(2 bytes)
+	minSize := unencryptedBytes + 16 + 2
 	if len(payload) < minSize {
 		return nil, ErrMalformedPayload
 	}
@@ -195,30 +218,37 @@ func (e *E2EEContext) DecryptVideo(payload []byte) ([]byte, error) {
 	ivLen := int(frameTrailer[0])
 	// KID := frameTrailer[1] // Key ID - ignored, we use externally provided key
 
-	if ivLen > len(payload)-2-unencryptedVideoBytes {
+	if ivLen > len(payload)-2-unencryptedBytes {
 		return nil, ErrMalformedPayload
 	}
 
 	// Extract components
-	frameHeader := payload[:unencryptedVideoBytes]
+	frameHeader := payload[:unencryptedBytes]
 	ivStart := len(payload) - 2 - ivLen
 	iv := payload[ivStart : ivStart+ivLen]
 
-	cipherTextStart := unencryptedVideoBytes
+	cipherTextStart := unencryptedBytes
 	cipherTextEnd := ivStart
 	cipherText := payload[cipherTextStart:cipherTextEnd]
+
+	// Apply RBSP unescaping if needed for H264
+	// This removes emulation prevention bytes (0x00 0x00 0x03 → 0x00 0x00)
+	// that may have been inserted during encryption
+	if needsRBSPUnescaping(cipherText) {
+		cipherText = parseRBSP(cipherText)
+	}
 
 	// Create GCM cipher with the IV length from the payload
 	aesGCM, err := cipher.NewGCMWithNonceSize(cipherBlock, ivLen)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create GCM cipher: %w", err)
+		return nil, fmt.Errorf("create GCM cipher: %w", err)
 	}
 
 	// Decrypt using authenticated decryption
 	// The frame header is used as Additional Authenticated Data (AAD)
 	plainText, err := aesGCM.Open(nil, iv, cipherText, frameHeader)
 	if err != nil {
-		return nil, fmt.Errorf("video decryption failed: %w", err)
+		return nil, fmt.Errorf("video decryption: %w", err)
 	}
 
 	// Reconstruct the decrypted payload: frameHeader + plainText
@@ -246,4 +276,281 @@ func (e *E2EEContext) IsSIFFrame(payload []byte) bool {
 
 	possibleTrailer := payload[len(payload)-len(sifTrailer):]
 	return bytes.Equal(possibleTrailer, sifTrailer)
+}
+
+// getH264UnencryptedBytes returns the number of unencrypted header bytes
+// based on the H264 RTP packet type.
+//
+// H264 RTP packets have different structures depending on the NAL unit type:
+//   - Single NAL (types 1-23): 1 byte NAL header remains unencrypted
+//   - FU-A (type 28): 2 bytes (FU indicator + FU header) remain unencrypted
+//   - STAP-A (type 24): 1 byte NAL header (aggregation handled specially)
+//
+// The unencrypted bytes serve as AAD (Additional Authenticated Data) during
+// AES-GCM encryption, so the correct value must match what the encryptor used.
+func getH264UnencryptedBytes(payload []byte) int {
+	if len(payload) == 0 {
+		return 0
+	}
+
+	// NAL unit type is in the lower 5 bits of the first byte
+	nalType := payload[0] & 0x1F
+
+	switch {
+	case nalType >= nalTypeSingleMin && nalType <= nalTypeSingleMax:
+		// Single NAL unit packet: 1 byte NAL header
+		return 1
+	case nalType == nalTypeFUA:
+		// FU-A fragmented unit: 1 byte FU indicator + 1 byte FU header
+		return 2
+	case nalType == nalTypeSTAPA:
+		// STAP-A aggregated: 1 byte NAL header (content has variable structure)
+		return 1
+	default:
+		// Unknown/unsupported type, use 1 byte as fallback
+		return 1
+	}
+}
+
+// needsRBSPUnescaping checks if the data contains emulation prevention bytes
+// (0x00 0x00 0x03 sequence) that need to be removed before decryption.
+//
+// In H264, the byte sequence 0x00 0x00 is reserved for start codes.
+// To prevent accidental start codes within NAL unit data, an emulation
+// prevention byte (0x03) is inserted: 0x00 0x00 0x00 → 0x00 0x00 0x03 0x00.
+// This function checks if such escaping is present.
+//
+// Reference: LiveKit client-sdk-js/src/e2ee/utils.ts
+func needsRBSPUnescaping(data []byte) bool {
+	for i := 0; i < len(data)-2; i++ {
+		if data[i] == 0 && data[i+1] == 0 && data[i+2] == 3 {
+			return true
+		}
+	}
+	return false
+}
+
+// parseRBSP removes emulation prevention bytes (0x03) from the data.
+//
+// In H264, 0x00 0x00 0x03 sequences are used to prevent start code patterns
+// within NAL units. This function reverses that escaping by removing the
+// 0x03 bytes, restoring the original data.
+//
+// Example transformations:
+//   - 0x00 0x00 0x03 0x00 → 0x00 0x00 0x00
+//   - 0x00 0x00 0x03 0x01 → 0x00 0x00 0x01
+//   - 0x00 0x00 0x03 0x02 → 0x00 0x00 0x02
+//   - 0x00 0x00 0x03 0x03 → 0x00 0x00 0x03
+//
+// Reference: LiveKit client-sdk-js/src/e2ee/utils.ts
+func parseRBSP(data []byte) []byte {
+	result := make([]byte, 0, len(data))
+	for i := 0; i < len(data); {
+		if i < len(data)-2 && data[i] == 0 && data[i+1] == 0 && data[i+2] == 3 {
+			// Found emulation prevention sequence, keep the two zeros but skip the 0x03
+			result = append(result, data[i], data[i+1])
+			i += 3 // Skip past the 0x03 emulation prevention byte
+		} else {
+			result = append(result, data[i])
+			i++
+		}
+	}
+	return result
+}
+
+// H264 slice NAL types (for finding unencrypted bytes boundary in frame-level decryption)
+const (
+	h264FrameNALTypeNonIDRSlice = 1 // Non-IDR slice (P/B frame)
+	h264FrameNALTypeIDRSlice    = 5 // IDR slice (keyframe)
+)
+
+// findNALUIndices finds NALU boundaries by scanning for start codes.
+// Returns indices where NAL units start (AFTER the start code, pointing to NAL header).
+//
+// H264 Annex B format uses start codes to delimit NAL units:
+//   - 3-byte start code: 0x00 0x00 0x01
+//   - 4-byte start code: 0x00 0x00 0x00 0x01
+//
+// This function is ported from LiveKit client-sdk-js/src/e2ee/naluUtils.ts
+//
+// Example:
+//
+//	Input:  [0x00 0x00 0x00 0x01 0x67 ... 0x00 0x00 0x01 0x68 ...]
+//	Output: [4, 12]  // indices of 0x67 and 0x68 (NAL headers)
+func findNALUIndices(data []byte) []int {
+	var indices []int
+
+	for i := 0; i < len(data); {
+		// Check for 4-byte start code: 0x00 0x00 0x00 0x01
+		if i+3 < len(data) && data[i] == 0 && data[i+1] == 0 && data[i+2] == 0 && data[i+3] == 1 {
+			indices = append(indices, i+4)
+			i += 4
+			continue
+		}
+
+		// Check for 3-byte start code: 0x00 0x00 0x01
+		if i+2 < len(data) && data[i] == 0 && data[i+1] == 0 && data[i+2] == 1 {
+			indices = append(indices, i+3)
+			i += 3
+			continue
+		}
+
+		i++
+	}
+
+	return indices
+}
+
+// isH264SliceNALU returns true if the NAL type is a slice (IDR or non-IDR).
+// These are the NAL units that contain actual video data that gets encrypted.
+func isH264SliceNALU(nalType byte) bool {
+	return nalType == h264FrameNALTypeNonIDRSlice || nalType == h264FrameNALTypeIDRSlice
+}
+
+// findSliceNALUUnencryptedBytes finds the first slice NALU and returns the
+// number of unencrypted bytes (everything up to and including first 2 bytes of slice).
+//
+// This matches the LiveKit client-sdk-js implementation:
+//   - Find NALUs by scanning for start codes
+//   - Find first slice NALU (type 1 = non-IDR, type 5 = IDR)
+//   - Return index_of_slice_NALU + 2 as unencrypted bytes
+//
+// The unencrypted portion (AAD) includes:
+//   - All start codes before the first slice
+//   - All NALUs before the first slice (SPS, PPS, SEI, etc.)
+//   - First 2 bytes of the slice NALU (NAL header + first slice byte)
+//
+// Returns 0 if no slice NALU is found (should not happen for valid video frames).
+func findSliceNALUUnencryptedBytes(data []byte, naluIndices []int) int {
+	for _, idx := range naluIndices {
+		if idx >= len(data) {
+			continue
+		}
+		nalType := data[idx] & 0x1F
+		if isH264SliceNALU(nalType) {
+			// Return index + 2 (NAL header byte + first slice data byte)
+			unencrypted := idx + 2
+			if unencrypted > len(data) {
+				unencrypted = len(data)
+			}
+			return unencrypted
+		}
+	}
+	return 0
+}
+
+// DecryptVideoFrame decrypts a complete E2EE-encrypted video frame in Annex B format.
+//
+// This function implements the same decryption algorithm as the LiveKit JS SDK's
+// FrameCryptor.decryptFrame() method. It expects a complete video frame assembled
+// from RTP packets and converted to Annex B format.
+//
+// Algorithm:
+//  1. Find NALU indices by scanning for start codes (0x00 0x00 0x01 or 0x00 0x00 0x00 0x01)
+//  2. Find first slice NALU (type 1 or 5) to determine unencryptedBytes
+//  3. Extract frame header (AAD) = data[0:unencryptedBytes]
+//  4. Extract encrypted data = data[unencryptedBytes:]
+//  5. Apply RBSP unescaping to encrypted data if needed
+//  6. Parse trailer: last 2 bytes are [ivLength][KID]
+//  7. Extract IV and ciphertext
+//  8. Decrypt using AES-GCM with frame header as AAD
+//  9. Return reconstructed frame: header + plaintext
+//
+// Encrypted frame format:
+//
+//	[frameHeader (unencryptedBytes)][ciphertext][IV][ivLength (1 byte)][KID (1 byte)]
+//
+// Parameters:
+//   - annexBFrame: Complete video frame in Annex B format (with start codes)
+//
+// Returns:
+//   - Decrypted frame in Annex B format on success
+//   - nil with no error for Server Injected Frames
+//   - Error if decryption fails
+func (e *E2EEContext) DecryptVideoFrame(annexBFrame []byte) ([]byte, error) {
+	if !e.Enabled() {
+		return nil, ErrE2EENotEnabled
+	}
+
+	e.mu.RLock()
+	cipherBlock := e.cipherBlock
+	sifTrailer := e.sifTrailer
+	e.mu.RUnlock()
+
+	// Check for Server Injected Frame
+	if sifTrailer != nil && len(annexBFrame) >= len(sifTrailer) {
+		possibleTrailer := annexBFrame[len(annexBFrame)-len(sifTrailer):]
+		if bytes.Equal(possibleTrailer, sifTrailer) {
+			return nil, nil
+		}
+	}
+
+	// Step 1: Find NALU indices using start codes
+	naluIndices := findNALUIndices(annexBFrame)
+	if len(naluIndices) == 0 {
+		return nil, fmt.Errorf("no NAL units found in frame")
+	}
+
+	// Step 2: Find first slice NALU and calculate unencrypted bytes
+	unencryptedBytes := findSliceNALUUnencryptedBytes(annexBFrame, naluIndices)
+	if unencryptedBytes == 0 {
+		// No slice NALU found - might be SPS/PPS only frame, pass through
+		return annexBFrame, nil
+	}
+
+	// Step 3: Minimum frame size check
+	// frameHeader + ciphertext(16 byte auth tag min) + IV(1 min) + trailer(2 bytes)
+	minSize := unencryptedBytes + 16 + 1 + 2
+	if len(annexBFrame) < minSize {
+		return nil, ErrMalformedPayload
+	}
+
+	// Step 4: Extract frame header (AAD)
+	frameHeader := annexBFrame[:unencryptedBytes]
+
+	// Step 5: Extract encrypted data
+	encryptedData := annexBFrame[unencryptedBytes:]
+
+	// Step 6: Apply RBSP unescaping to encrypted data if needed
+	// The JS SDK applies this to the encrypted portion before decryption
+	if needsRBSPUnescaping(encryptedData) {
+		encryptedData = parseRBSP(encryptedData)
+	}
+
+	// Step 7: Parse trailer - last 2 bytes are [ivLength][KID]
+	if len(encryptedData) < 2 {
+		return nil, ErrMalformedPayload
+	}
+	frameTrailer := encryptedData[len(encryptedData)-2:]
+	ivLength := int(frameTrailer[0])
+	// KID := frameTrailer[1] // Key ID - ignored, we use externally provided key
+
+	// Step 8: Extract IV
+	if ivLength > len(encryptedData)-2 {
+		return nil, ErrMalformedPayload
+	}
+	ivStart := len(encryptedData) - 2 - ivLength
+	iv := encryptedData[ivStart : ivStart+ivLength]
+
+	// Step 9: Extract ciphertext (everything before IV)
+	ciphertext := encryptedData[:ivStart]
+
+	// Step 10: Create GCM cipher with the IV length from the payload
+	aesGCM, err := cipher.NewGCMWithNonceSize(cipherBlock, ivLength)
+	if err != nil {
+		return nil, fmt.Errorf("create GCM cipher: %w", err)
+	}
+
+	// Step 11: Decrypt using authenticated decryption with frame header as AAD
+	plaintext, err := aesGCM.Open(nil, iv, ciphertext, frameHeader)
+	if err != nil {
+		return nil, fmt.Errorf("video frame decryption: %w", err)
+	}
+
+	// Step 12: Reconstruct the decrypted frame: frameHeader + plaintext
+	result := make([]byte, len(frameHeader)+len(plaintext))
+	copy(result[:len(frameHeader)], frameHeader)
+	copy(result[len(frameHeader):], plaintext)
+
+	return result, nil
 }

--- a/examples/publisher-hls-agent/e2ee_test.go
+++ b/examples/publisher-hls-agent/e2ee_test.go
@@ -1,0 +1,426 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetH264UnencryptedBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		payload  []byte
+		expected int
+	}{
+		{
+			name:     "empty payload",
+			payload:  []byte{},
+			expected: 0,
+		},
+		{
+			name: "single NAL - IDR (type 5)",
+			payload: []byte{
+				0x65, // IDR NAL unit type (0x65 & 0x1F = 5)
+				0x01, 0x02, 0x03,
+			},
+			expected: 1,
+		},
+		{
+			name: "single NAL - non-IDR (type 1)",
+			payload: []byte{
+				0x41, // non-IDR NAL unit type (0x41 & 0x1F = 1)
+				0x01, 0x02, 0x03,
+			},
+			expected: 1,
+		},
+		{
+			name: "single NAL - SPS (type 7)",
+			payload: []byte{
+				0x67, // SPS NAL unit type (0x67 & 0x1F = 7)
+				0x01, 0x02, 0x03,
+			},
+			expected: 1,
+		},
+		{
+			name: "single NAL - PPS (type 8)",
+			payload: []byte{
+				0x68, // PPS NAL unit type (0x68 & 0x1F = 8)
+				0x01, 0x02, 0x03,
+			},
+			expected: 1,
+		},
+		{
+			name: "FU-A (type 28)",
+			payload: []byte{
+				0x7C, // FU indicator (0x7C & 0x1F = 28)
+				0x85, // FU header (S=1, E=0, R=0, Type=5)
+				0x01, 0x02, 0x03,
+			},
+			expected: 2,
+		},
+		{
+			name: "FU-A middle fragment",
+			payload: []byte{
+				0x7C, // FU indicator (type 28)
+				0x05, // FU header (S=0, E=0, R=0, Type=5)
+				0x01, 0x02, 0x03,
+			},
+			expected: 2,
+		},
+		{
+			name: "FU-A end fragment",
+			payload: []byte{
+				0x7C, // FU indicator (type 28)
+				0x45, // FU header (S=0, E=1, R=0, Type=5)
+				0x01, 0x02, 0x03,
+			},
+			expected: 2,
+		},
+		{
+			name: "STAP-A (type 24)",
+			payload: []byte{
+				0x78,       // STAP-A type (0x78 & 0x1F = 24)
+				0x00, 0x04, // Size
+				0x67, 0x01, 0x02, 0x03,
+			},
+			expected: 1,
+		},
+		{
+			name: "unknown NAL type (>23, not special)",
+			payload: []byte{
+				0x79, // Type 25 - unknown
+				0x01, 0x02, 0x03,
+			},
+			expected: 1, // fallback
+		},
+		{
+			name: "single NAL - type 23 (max single)",
+			payload: []byte{
+				0x77, // Type 23 (0x77 & 0x1F = 23)
+				0x01, 0x02, 0x03,
+			},
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getH264UnencryptedBytes(tt.payload)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestNeedsRBSPUnescaping(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		expected bool
+	}{
+		{
+			name:     "empty data",
+			data:     []byte{},
+			expected: false,
+		},
+		{
+			name:     "short data (1 byte)",
+			data:     []byte{0x00},
+			expected: false,
+		},
+		{
+			name:     "short data (2 bytes)",
+			data:     []byte{0x00, 0x00},
+			expected: false,
+		},
+		{
+			name:     "no emulation prevention needed",
+			data:     []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+			expected: false,
+		},
+		{
+			name:     "has emulation prevention at start",
+			data:     []byte{0x00, 0x00, 0x03, 0x00, 0x05},
+			expected: true,
+		},
+		{
+			name:     "has emulation prevention in middle",
+			data:     []byte{0x01, 0x02, 0x00, 0x00, 0x03, 0x01, 0x05},
+			expected: true,
+		},
+		{
+			name:     "has emulation prevention at end",
+			data:     []byte{0x01, 0x02, 0x00, 0x00, 0x03},
+			expected: true,
+		},
+		{
+			name:     "multiple emulation prevention bytes",
+			data:     []byte{0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x03, 0x01},
+			expected: true,
+		},
+		{
+			name:     "0x00 0x00 without 0x03",
+			data:     []byte{0x00, 0x00, 0x01, 0x02, 0x03},
+			expected: false,
+		},
+		{
+			name:     "0x00 0x00 0x04 (not prevention byte)",
+			data:     []byte{0x00, 0x00, 0x04, 0x05},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := needsRBSPUnescaping(tt.data)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestFindNALUIndices(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		expected []int
+	}{
+		{
+			name:     "empty data",
+			data:     []byte{},
+			expected: nil,
+		},
+		{
+			name:     "no start codes",
+			data:     []byte{0x01, 0x02, 0x03, 0x04},
+			expected: nil,
+		},
+		{
+			name: "single 3-byte start code",
+			data: []byte{
+				0x00, 0x00, 0x01, // 3-byte start code
+				0x67, 0x01, 0x02, // SPS NAL
+			},
+			expected: []int{3}, // Index of 0x67
+		},
+		{
+			name: "single 4-byte start code",
+			data: []byte{
+				0x00, 0x00, 0x00, 0x01, // 4-byte start code
+				0x67, 0x01, 0x02, // SPS NAL
+			},
+			expected: []int{4}, // Index of 0x67
+		},
+		{
+			name: "multiple NALUs with 4-byte start codes",
+			data: []byte{
+				0x00, 0x00, 0x00, 0x01, // Start code
+				0x67, 0x01, 0x02, // SPS
+				0x00, 0x00, 0x00, 0x01, // Start code
+				0x68, 0x03, // PPS
+				0x00, 0x00, 0x00, 0x01, // Start code
+				0x65, 0x04, 0x05, // IDR
+			},
+			expected: []int{4, 11, 17}, // Indices of NAL headers
+		},
+		{
+			name: "mixed 3-byte and 4-byte start codes",
+			data: []byte{
+				0x00, 0x00, 0x00, 0x01, // 4-byte start code
+				0x67, 0x01, // SPS
+				0x00, 0x00, 0x01, // 3-byte start code
+				0x68, 0x02, // PPS
+			},
+			expected: []int{4, 9}, // Indices of NAL headers
+		},
+		{
+			name: "start code at end (incomplete)",
+			data: []byte{
+				0x00, 0x00, 0x00, 0x01,
+				0x67, 0x01,
+				0x00, 0x00, 0x01, // Start code at end, but no NAL data
+			},
+			expected: []int{4, 9},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findNALUIndices(tt.data)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestIsH264SliceNALU(t *testing.T) {
+	tests := []struct {
+		name     string
+		nalType  byte
+		expected bool
+	}{
+		{"non-IDR slice type 1", 1, true},
+		{"IDR slice type 5", 5, true},
+		{"SPS type 7", 7, false},
+		{"PPS type 8", 8, false},
+		{"SEI type 6", 6, false},
+		{"AUD type 9", 9, false},
+		{"type 0", 0, false},
+		{"type 2", 2, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isH264SliceNALU(tt.nalType)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestFindSliceNALUUnencryptedBytes(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		naluIndices []int
+		expected    int
+	}{
+		{
+			name:        "empty indices",
+			data:        []byte{0x67, 0x01, 0x02},
+			naluIndices: []int{},
+			expected:    0,
+		},
+		{
+			name: "first NALU is IDR slice",
+			data: []byte{
+				0x00, 0x00, 0x00, 0x01,
+				0x65, 0x01, 0x02, 0x03, // IDR at index 4
+			},
+			naluIndices: []int{4},
+			expected:    6, // 4 + 2
+		},
+		{
+			name: "SPS, PPS, then IDR slice",
+			data: []byte{
+				0x00, 0x00, 0x00, 0x01,
+				0x67, 0x01, 0x02, // SPS at index 4
+				0x00, 0x00, 0x00, 0x01,
+				0x68, 0x03, // PPS at index 11
+				0x00, 0x00, 0x00, 0x01,
+				0x65, 0x04, 0x05, 0x06, // IDR at index 17
+			},
+			naluIndices: []int{4, 11, 17},
+			expected:    19, // 17 + 2
+		},
+		{
+			name: "non-IDR slice type 1",
+			data: []byte{
+				0x00, 0x00, 0x00, 0x01,
+				0x41, 0x01, 0x02, // Non-IDR (type 1) at index 4
+			},
+			naluIndices: []int{4},
+			expected:    6, // 4 + 2
+		},
+		{
+			name: "no slice NALU (only SPS/PPS)",
+			data: []byte{
+				0x00, 0x00, 0x00, 0x01,
+				0x67, 0x01, // SPS
+				0x00, 0x00, 0x00, 0x01,
+				0x68, 0x02, // PPS
+			},
+			naluIndices: []int{4, 10},
+			expected:    0, // No slice found
+		},
+		{
+			name:        "index out of bounds",
+			data:        []byte{0x00, 0x00, 0x00, 0x01, 0x67},
+			naluIndices: []int{4, 100}, // 100 is out of bounds
+			expected:    0,             // No valid slice
+		},
+		{
+			name: "slice at end with limited data",
+			data: []byte{
+				0x00, 0x00, 0x00, 0x01,
+				0x65, 0x01, // IDR at index 4, only 2 bytes after
+			},
+			naluIndices: []int{4},
+			expected:    6, // 4 + 2, exactly at end
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findSliceNALUUnencryptedBytes(tt.data, tt.naluIndices)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestParseRBSP(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected []byte
+	}{
+		{
+			name:     "empty data",
+			input:    []byte{},
+			expected: []byte{},
+		},
+		{
+			name:     "no emulation prevention",
+			input:    []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+			expected: []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+		},
+		{
+			name:     "single emulation prevention 0x00 0x00 0x03 0x00",
+			input:    []byte{0x00, 0x00, 0x03, 0x00},
+			expected: []byte{0x00, 0x00, 0x00},
+		},
+		{
+			name:     "single emulation prevention 0x00 0x00 0x03 0x01",
+			input:    []byte{0x00, 0x00, 0x03, 0x01},
+			expected: []byte{0x00, 0x00, 0x01},
+		},
+		{
+			name:     "single emulation prevention 0x00 0x00 0x03 0x02",
+			input:    []byte{0x00, 0x00, 0x03, 0x02},
+			expected: []byte{0x00, 0x00, 0x02},
+		},
+		{
+			name:     "single emulation prevention 0x00 0x00 0x03 0x03",
+			input:    []byte{0x00, 0x00, 0x03, 0x03},
+			expected: []byte{0x00, 0x00, 0x03},
+		},
+		{
+			name:     "emulation prevention in middle",
+			input:    []byte{0x01, 0x02, 0x00, 0x00, 0x03, 0x01, 0x04, 0x05},
+			expected: []byte{0x01, 0x02, 0x00, 0x00, 0x01, 0x04, 0x05},
+		},
+		{
+			name:     "multiple emulation preventions",
+			input:    []byte{0x00, 0x00, 0x03, 0x00, 0x01, 0x00, 0x00, 0x03, 0x01},
+			expected: []byte{0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x01},
+		},
+		{
+			name:     "consecutive emulation preventions",
+			input:    []byte{0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x01},
+			expected: []byte{0x00, 0x00, 0x00, 0x00, 0x01},
+		},
+		{
+			name:     "short data (2 bytes)",
+			input:    []byte{0x00, 0x00},
+			expected: []byte{0x00, 0x00},
+		},
+		{
+			name:     "0x00 0x00 at end without 0x03",
+			input:    []byte{0x01, 0x02, 0x00, 0x00},
+			expected: []byte{0x01, 0x02, 0x00, 0x00},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseRBSP(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/examples/publisher-hls-agent/frame_assembler.go
+++ b/examples/publisher-hls-agent/frame_assembler.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"bytes"
+	"sort"
+	"sync"
+
+	"github.com/pion/rtp"
+)
+
+// H264 NAL unit types for RTP packet classification (RFC 6184)
+const (
+	// Single NAL unit types (1-23)
+	h264NALTypeSingleMin = 1
+	h264NALTypeSingleMax = 23
+	// STAP-A (24) - Single-Time Aggregation Packet type A
+	h264NALTypeSTAPA = 24
+	// FU-A (28) - Fragmentation Unit type A
+	h264NALTypeFUA = 28
+)
+
+// rtpFragment holds a single RTP packet fragment for frame assembly
+type rtpFragment struct {
+	seqNum  uint16
+	payload []byte
+	marker  bool // RTP marker bit indicates end of frame
+}
+
+// FrameAssembler collects RTP packets and assembles them into complete H264 frames
+// in Annex B format for E2EE decryption.
+//
+// The JS SDK encrypts complete video frames in Annex B format (with start codes).
+// RTP packets use RFC 6184 format (without start codes). This assembler:
+// 1. Collects RTP packets by timestamp
+// 2. Sorts them by sequence number
+// 3. Converts to Annex B format (adds start codes, handles FU-A reassembly)
+// 4. Returns complete frames for decryption
+type FrameAssembler struct {
+	mu        sync.Mutex
+	fragments map[uint32][]rtpFragment // keyed by RTP timestamp
+
+	// FU-A state for current frame being assembled
+	fuaBuffer   []byte // accumulated FU-A payload
+	fuaNRI      byte   // F and NRI bits from FU indicator
+	fuaNALType  byte   // NAL type from FU header
+	fuaStarted  bool   // have we seen start fragment?
+	fuaComplete bool   // have we seen end fragment?
+}
+
+// NewFrameAssembler creates a new frame assembler
+func NewFrameAssembler() *FrameAssembler {
+	return &FrameAssembler{
+		fragments: make(map[uint32][]rtpFragment),
+	}
+}
+
+// AddPacket adds an RTP packet to the assembler.
+// Returns (completeFrame, timestamp, complete) where:
+//   - completeFrame: the assembled Annex B frame if complete
+//   - timestamp: the RTP timestamp of the frame
+//   - complete: true if a frame was completed
+func (fa *FrameAssembler) AddPacket(pkt *rtp.Packet) ([]byte, uint32, bool) {
+	if pkt == nil || len(pkt.Payload) == 0 {
+		return nil, 0, false
+	}
+
+	fa.mu.Lock()
+	defer fa.mu.Unlock()
+
+	ts := pkt.Timestamp
+	frag := rtpFragment{
+		seqNum:  pkt.SequenceNumber,
+		payload: make([]byte, len(pkt.Payload)),
+		marker:  pkt.Marker,
+	}
+	copy(frag.payload, pkt.Payload)
+
+	fa.fragments[ts] = append(fa.fragments[ts], frag)
+
+	// Check if frame is complete (marker bit indicates last packet of frame)
+	if pkt.Marker {
+		frame := fa.assembleFrame(ts)
+		delete(fa.fragments, ts)
+		return frame, ts, frame != nil
+	}
+
+	return nil, 0, false
+}
+
+// assembleFrame converts collected RTP packets into Annex B format
+func (fa *FrameAssembler) assembleFrame(ts uint32) []byte {
+	frags, ok := fa.fragments[ts]
+	if !ok || len(frags) == 0 {
+		return nil
+	}
+
+	// Sort by sequence number (handle wraparound)
+	sort.Slice(frags, func(i, j int) bool {
+		return seqLess(frags[i].seqNum, frags[j].seqNum)
+	})
+
+	var result bytes.Buffer
+
+	// Reset FU-A state
+	fa.fuaBuffer = nil
+	fa.fuaNRI = 0
+	fa.fuaNALType = 0
+	fa.fuaStarted = false
+	fa.fuaComplete = false
+
+	for _, frag := range frags {
+		if len(frag.payload) == 0 {
+			continue
+		}
+
+		nalType := frag.payload[0] & 0x1F
+
+		switch {
+		case nalType >= h264NALTypeSingleMin && nalType <= h264NALTypeSingleMax:
+			// Single NAL unit - add 4-byte start code and the NAL unit
+			result.Write([]byte{0x00, 0x00, 0x00, 0x01})
+			result.Write(frag.payload)
+
+		case nalType == h264NALTypeSTAPA:
+			// STAP-A - split aggregated NALUs
+			fa.parseSTAPA(frag.payload, &result)
+
+		case nalType == h264NALTypeFUA:
+			// FU-A - handle fragmented NAL unit
+			fa.parseFUA(frag.payload, &result)
+		}
+	}
+
+	// If we have incomplete FU-A data, flush it
+	if fa.fuaStarted && len(fa.fuaBuffer) > 0 {
+		// Reconstruct NAL header: F and NRI from indicator, type from FU header
+		nalHeader := fa.fuaNRI | fa.fuaNALType
+		result.Write([]byte{0x00, 0x00, 0x00, 0x01})
+		result.WriteByte(nalHeader)
+		result.Write(fa.fuaBuffer)
+	}
+
+	if result.Len() == 0 {
+		return nil
+	}
+
+	return result.Bytes()
+}
+
+// parseSTAPA parses a STAP-A packet and writes NAL units to result
+func (fa *FrameAssembler) parseSTAPA(payload []byte, result *bytes.Buffer) {
+	if len(payload) < 3 {
+		return
+	}
+
+	offset := 1 // Skip STAP-A header
+	for offset+2 <= len(payload) {
+		nalSize := int(payload[offset])<<8 | int(payload[offset+1])
+		offset += 2
+
+		if nalSize <= 0 || offset+nalSize > len(payload) {
+			break
+		}
+
+		// Add 4-byte start code and NAL unit
+		result.Write([]byte{0x00, 0x00, 0x00, 0x01})
+		result.Write(payload[offset : offset+nalSize])
+
+		offset += nalSize
+	}
+}
+
+// parseFUA parses a FU-A packet and accumulates the NAL unit data
+func (fa *FrameAssembler) parseFUA(payload []byte, result *bytes.Buffer) {
+	if len(payload) < 2 {
+		return
+	}
+
+	fuIndicator := payload[0]
+	fuHeader := payload[1]
+
+	startBit := (fuHeader & 0x80) != 0
+	endBit := (fuHeader & 0x40) != 0
+	nalType := fuHeader & 0x1F
+
+	// Extract F and NRI bits from FU indicator (upper 3 bits)
+	fnri := fuIndicator & 0xE0
+
+	if startBit {
+		// Start of fragmented NAL - save the header info
+		fa.fuaNRI = fnri
+		fa.fuaNALType = nalType
+		fa.fuaBuffer = make([]byte, 0, len(payload)*10) // Pre-allocate
+		fa.fuaStarted = true
+		fa.fuaComplete = false
+	}
+
+	if !fa.fuaStarted {
+		// Received continuation/end without start - discard
+		return
+	}
+
+	// Append fragment data (skip FU indicator and FU header)
+	if len(payload) > 2 {
+		fa.fuaBuffer = append(fa.fuaBuffer, payload[2:]...)
+	}
+
+	if endBit {
+		// End of fragmented NAL - write complete NAL unit
+		nalHeader := fa.fuaNRI | fa.fuaNALType
+		result.Write([]byte{0x00, 0x00, 0x00, 0x01})
+		result.WriteByte(nalHeader)
+		result.Write(fa.fuaBuffer)
+
+		// Reset FU-A state
+		fa.fuaBuffer = nil
+		fa.fuaStarted = false
+		fa.fuaComplete = true
+	}
+}
+
+// seqLess compares two sequence numbers accounting for wraparound
+func seqLess(a, b uint16) bool {
+	// Handle wraparound: if difference is > 32768, assume wraparound
+	diff := int32(a) - int32(b)
+	if diff > 32768 {
+		diff -= 65536
+	} else if diff < -32768 {
+		diff += 65536
+	}
+	return diff < 0
+}
+
+// Cleanup removes old incomplete frames (call periodically to prevent memory leaks)
+func (fa *FrameAssembler) Cleanup(maxAge int) {
+	fa.mu.Lock()
+	defer fa.mu.Unlock()
+
+	// Simple cleanup: if we have too many incomplete frames, clear them all
+	// A more sophisticated approach would track timestamps and age
+	if len(fa.fragments) > maxAge {
+		fa.fragments = make(map[uint32][]rtpFragment)
+	}
+}
+
+// Clear removes all buffered fragments
+func (fa *FrameAssembler) Clear() {
+	fa.mu.Lock()
+	defer fa.mu.Unlock()
+	fa.fragments = make(map[uint32][]rtpFragment)
+	fa.fuaBuffer = nil
+	fa.fuaStarted = false
+}

--- a/examples/publisher-hls-agent/frame_assembler_test.go
+++ b/examples/publisher-hls-agent/frame_assembler_test.go
@@ -1,0 +1,314 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFrameAssembler_SingleNALPacket(t *testing.T) {
+	fa := NewFrameAssembler()
+
+	// Create a single NAL unit packet (IDR keyframe type 5)
+	// Format: [NAL header (1 byte)][NAL payload]
+	pkt := &rtp.Packet{
+		Header: rtp.Header{
+			SequenceNumber: 1,
+			Timestamp:      1000,
+			Marker:         true, // End of frame
+		},
+		Payload: []byte{
+			0x65,                   // NAL header: type 5 (IDR)
+			0x01, 0x02, 0x03, 0x04, // NAL payload
+		},
+	}
+
+	frame, ts, complete := fa.AddPacket(pkt)
+	assert.True(t, complete, "Single NAL with marker should complete frame")
+	assert.Equal(t, uint32(1000), ts, "Timestamp should match")
+
+	// Should have Annex B format: start code + NAL unit
+	expected := []byte{
+		0x00, 0x00, 0x00, 0x01, // 4-byte start code
+		0x65, 0x01, 0x02, 0x03, 0x04, // NAL unit
+	}
+	assert.Equal(t, expected, frame)
+}
+
+func TestFrameAssembler_FUAPackets(t *testing.T) {
+	fa := NewFrameAssembler()
+
+	// FU-A start packet
+	startPkt := &rtp.Packet{
+		Header: rtp.Header{
+			SequenceNumber: 1,
+			Timestamp:      1000,
+			Marker:         false,
+		},
+		Payload: []byte{
+			0x7C,       // FU indicator: F=0, NRI=3, Type=28 (FU-A)
+			0x85,       // FU header: S=1 (start), E=0, Type=5 (IDR)
+			0x01, 0x02, // Fragment data
+		},
+	}
+
+	// FU-A middle packet
+	midPkt := &rtp.Packet{
+		Header: rtp.Header{
+			SequenceNumber: 2,
+			Timestamp:      1000,
+			Marker:         false,
+		},
+		Payload: []byte{
+			0x7C,       // FU indicator
+			0x05,       // FU header: S=0, E=0, Type=5
+			0x03, 0x04, // Fragment data
+		},
+	}
+
+	// FU-A end packet
+	endPkt := &rtp.Packet{
+		Header: rtp.Header{
+			SequenceNumber: 3,
+			Timestamp:      1000,
+			Marker:         true, // End of frame
+		},
+		Payload: []byte{
+			0x7C,       // FU indicator
+			0x45,       // FU header: S=0, E=1 (end), Type=5
+			0x05, 0x06, // Fragment data
+		},
+	}
+
+	// Add packets
+	_, _, complete := fa.AddPacket(startPkt)
+	assert.False(t, complete, "Start packet should not complete frame")
+
+	_, _, complete = fa.AddPacket(midPkt)
+	assert.False(t, complete, "Middle packet should not complete frame")
+
+	frame, ts, complete := fa.AddPacket(endPkt)
+	assert.True(t, complete, "End packet should complete frame")
+	assert.Equal(t, uint32(1000), ts)
+
+	// Should have Annex B format: start code + reconstructed NAL unit
+	// NAL header = FU indicator NRI (0x60) | FU header Type (0x05) = 0x65
+	expected := []byte{
+		0x00, 0x00, 0x00, 0x01, // 4-byte start code
+		0x65,                               // Reconstructed NAL header (IDR)
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, // Fragment data
+	}
+	assert.Equal(t, expected, frame)
+}
+
+func TestFrameAssembler_STAPAPacket(t *testing.T) {
+	fa := NewFrameAssembler()
+
+	// STAP-A packet with SPS and PPS
+	pkt := &rtp.Packet{
+		Header: rtp.Header{
+			SequenceNumber: 1,
+			Timestamp:      1000,
+			Marker:         true,
+		},
+		Payload: []byte{
+			0x78, // STAP-A header: F=0, NRI=3, Type=24
+			// First NAL (SPS)
+			0x00, 0x03, // Size = 3
+			0x67, 0x01, 0x02, // SPS data
+			// Second NAL (PPS)
+			0x00, 0x02, // Size = 2
+			0x68, 0x03, // PPS data
+		},
+	}
+
+	frame, ts, complete := fa.AddPacket(pkt)
+	assert.True(t, complete)
+	assert.Equal(t, uint32(1000), ts)
+
+	// Should have Annex B format with start codes for each NAL
+	expected := []byte{
+		// First NAL (SPS)
+		0x00, 0x00, 0x00, 0x01,
+		0x67, 0x01, 0x02,
+		// Second NAL (PPS)
+		0x00, 0x00, 0x00, 0x01,
+		0x68, 0x03,
+	}
+	assert.Equal(t, expected, frame)
+}
+
+func TestFrameAssembler_MultiplePacketsSameTimestamp(t *testing.T) {
+	fa := NewFrameAssembler()
+
+	// Multiple single NAL packets with same timestamp
+	pkt1 := &rtp.Packet{
+		Header: rtp.Header{
+			SequenceNumber: 1,
+			Timestamp:      1000,
+			Marker:         false,
+		},
+		Payload: []byte{0x67, 0x01, 0x02}, // SPS
+	}
+
+	pkt2 := &rtp.Packet{
+		Header: rtp.Header{
+			SequenceNumber: 2,
+			Timestamp:      1000,
+			Marker:         false,
+		},
+		Payload: []byte{0x68, 0x03}, // PPS
+	}
+
+	pkt3 := &rtp.Packet{
+		Header: rtp.Header{
+			SequenceNumber: 3,
+			Timestamp:      1000,
+			Marker:         true, // End of frame
+		},
+		Payload: []byte{0x65, 0x04, 0x05}, // IDR
+	}
+
+	_, _, complete := fa.AddPacket(pkt1)
+	assert.False(t, complete)
+
+	_, _, complete = fa.AddPacket(pkt2)
+	assert.False(t, complete)
+
+	frame, _, complete := fa.AddPacket(pkt3)
+	assert.True(t, complete)
+
+	// Should have all NALUs with start codes
+	expected := []byte{
+		0x00, 0x00, 0x00, 0x01, 0x67, 0x01, 0x02, // SPS
+		0x00, 0x00, 0x00, 0x01, 0x68, 0x03, // PPS
+		0x00, 0x00, 0x00, 0x01, 0x65, 0x04, 0x05, // IDR
+	}
+	assert.Equal(t, expected, frame)
+}
+
+func TestFrameAssembler_OutOfOrderPackets(t *testing.T) {
+	fa := NewFrameAssembler()
+
+	// Packets arrive out of order
+	pkt2 := &rtp.Packet{
+		Header: rtp.Header{
+			SequenceNumber: 2,
+			Timestamp:      1000,
+			Marker:         false,
+		},
+		Payload: []byte{0x68, 0x02}, // PPS
+	}
+
+	pkt1 := &rtp.Packet{
+		Header: rtp.Header{
+			SequenceNumber: 1,
+			Timestamp:      1000,
+			Marker:         false,
+		},
+		Payload: []byte{0x67, 0x01}, // SPS
+	}
+
+	pkt3 := &rtp.Packet{
+		Header: rtp.Header{
+			SequenceNumber: 3,
+			Timestamp:      1000,
+			Marker:         true,
+		},
+		Payload: []byte{0x65, 0x03}, // IDR
+	}
+
+	fa.AddPacket(pkt2)
+	fa.AddPacket(pkt1)
+	frame, _, complete := fa.AddPacket(pkt3)
+	assert.True(t, complete)
+
+	// Should be sorted by sequence number
+	expected := []byte{
+		0x00, 0x00, 0x00, 0x01, 0x67, 0x01, // SPS (seq 1)
+		0x00, 0x00, 0x00, 0x01, 0x68, 0x02, // PPS (seq 2)
+		0x00, 0x00, 0x00, 0x01, 0x65, 0x03, // IDR (seq 3)
+	}
+	assert.Equal(t, expected, frame)
+}
+
+func TestFrameAssembler_EmptyPayload(t *testing.T) {
+	fa := NewFrameAssembler()
+
+	pkt := &rtp.Packet{
+		Header: rtp.Header{
+			SequenceNumber: 1,
+			Timestamp:      1000,
+			Marker:         true,
+		},
+		Payload: []byte{},
+	}
+
+	frame, _, complete := fa.AddPacket(pkt)
+	assert.False(t, complete, "Empty payload should not complete frame")
+	assert.Nil(t, frame)
+}
+
+func TestFrameAssembler_NilPacket(t *testing.T) {
+	fa := NewFrameAssembler()
+
+	frame, _, complete := fa.AddPacket(nil)
+	assert.False(t, complete)
+	assert.Nil(t, frame)
+}
+
+func TestFrameAssembler_Clear(t *testing.T) {
+	fa := NewFrameAssembler()
+
+	// Add some packets
+	pkt := &rtp.Packet{
+		Header: rtp.Header{
+			SequenceNumber: 1,
+			Timestamp:      1000,
+			Marker:         false,
+		},
+		Payload: []byte{0x67, 0x01},
+	}
+	fa.AddPacket(pkt)
+
+	// Clear should reset state
+	fa.Clear()
+
+	// Should start fresh
+	pkt2 := &rtp.Packet{
+		Header: rtp.Header{
+			SequenceNumber: 1,
+			Timestamp:      2000,
+			Marker:         true,
+		},
+		Payload: []byte{0x65, 0x02},
+	}
+	frame, ts, complete := fa.AddPacket(pkt2)
+	assert.True(t, complete)
+	assert.Equal(t, uint32(2000), ts)
+	assert.NotNil(t, frame)
+}
+
+func TestSeqLess(t *testing.T) {
+	tests := []struct {
+		name     string
+		a, b     uint16
+		expected bool
+	}{
+		{"simple less", 1, 2, true},
+		{"simple greater", 2, 1, false},
+		{"equal", 5, 5, false},
+		{"wraparound a less", 65535, 1, true},     // 65535 < 1 with wraparound
+		{"wraparound a greater", 1, 65535, false}, // 1 > 65535 with wraparound
+		{"near boundary less", 65530, 5, true},
+		{"near boundary greater", 5, 65530, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := seqLess(tt.a, tt.b)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/examples/publisher-hls-agent/go.mod
+++ b/examples/publisher-hls-agent/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/minio/minio-go/v7 v7.0.95
 	github.com/pion/rtp v1.8.22
 	github.com/pion/webrtc/v4 v4.1.5
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
@@ -23,6 +24,7 @@ require (
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/bep/debounce v1.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dennwc/iters v1.2.2 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
@@ -67,6 +69,7 @@ require (
 	github.com/pion/stun/v3 v3.0.0 // indirect
 	github.com/pion/transport/v3 v3.0.8 // indirect
 	github.com/pion/turn/v4 v4.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/puzpuzpuz/xsync/v3 v3.5.1 // indirect
 	github.com/redis/go-redis/v9 v9.12.1 // indirect
 	github.com/rs/xid v1.6.0 // indirect

--- a/examples/publisher-hls-agent/handler.go
+++ b/examples/publisher-hls-agent/handler.go
@@ -165,7 +165,7 @@ func (h *PublisherHLSHandler) OnJobAssigned(ctx context.Context, jobCtx *agent.J
 	participantIdentity := jobCtx.Job.Participant.Identity
 	roomName := jobCtx.Job.Room.Name
 
-	recorder, err := NewParticipantRecorder(h.cfg, roomName, participantIdentity)
+	recorder, err := NewParticipantRecorder(h.cfg, roomName, participantIdentity, h.cfg.E2EEEnabled())
 	if err != nil {
 		return fmt.Errorf("failed to create recorder: %w", err)
 	}

--- a/examples/publisher-hls-agent/recorder.go
+++ b/examples/publisher-hls-agent/recorder.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,6 +34,7 @@ type ParticipantRecorder struct {
 	room        string
 	outputDir   string
 	keepOpus    bool
+	logger      *slog.Logger
 
 	pipeline    *gst.Pipeline
 	videoAppSrc *app.Source
@@ -85,7 +87,12 @@ type ParticipantRecorder struct {
 
 	s3Uploader *RealtimeS3Uploader // Real-time S3 uploader (nil if disabled)
 
-	e2eeCtx *E2EEContext // E2EE decryption context (nil if disabled)
+	e2eeCtx        *E2EEContext    // E2EE decryption context (nil if disabled)
+	frameAssembler *FrameAssembler // Frame assembler for E2EE video decryption
+
+	// E2EE raw H264 video path (bypasses RTP depayload)
+	e2eeVideoAppSrc *app.Source
+	e2eeVideoQueue  *gst.Element
 }
 
 // Pre-buffer configuration for video and audio packets.
@@ -135,7 +142,8 @@ type RecordingSummary struct {
 //
 // Each recorder creates a unique temporary directory to support concurrent recordings.
 // Directory format: OUTPUT_DIR/room_participant_timestamp
-func NewParticipantRecorder(cfg *Config, roomName, participant string) (*ParticipantRecorder, error) {
+func NewParticipantRecorder(cfg *Config, roomName, participant string, e2eeEnabled bool) (*ParticipantRecorder, error) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	// Create single unique directory for this recording session
 	// Format: room_participant_timestamp (flat structure for easy cleanup)
 	timestamp := time.Now().Format("20060102-150405.000")
@@ -215,6 +223,48 @@ func NewParticipantRecorder(cfg *Config, roomName, participant string) (*Partici
 	_ = videoQueue.SetProperty("max-size-buffers", uint(0))
 	_ = videoQueue.SetProperty("max-size-bytes", uint(0))
 	_ = videoQueue.SetProperty("max-size-time", uint64(0))
+
+	// Create E2EE video pipeline elements only when E2EE is enabled
+	// This path is used when E2EE is enabled: encrypted RTP → frame assembly → decrypt → raw H264
+	var e2eeVideoSrc, e2eeH264Parse, e2eeVideoCapsFilter, e2eeVideoQueue *gst.Element
+	if e2eeEnabled {
+		e2eeVideoSrc, err = gst.NewElement("appsrc")
+		if err != nil {
+			return nil, fmt.Errorf("create e2ee video appsrc: %w", err)
+		}
+		_ = e2eeVideoSrc.SetProperty("is-live", true)
+		_ = e2eeVideoSrc.SetProperty("format", gst.FormatTime)
+		_ = e2eeVideoSrc.SetProperty("do-timestamp", false)
+		_ = e2eeVideoSrc.SetProperty("emit-signals", true)
+		_ = e2eeVideoSrc.SetProperty("block", false)
+		_ = e2eeVideoSrc.SetProperty("stream-type", 0)
+		_ = e2eeVideoSrc.SetProperty("max-bytes", uint64(10*1024*1024))
+		// Set caps for raw H264 Annex B format
+		e2eeCaps := gst.NewCapsFromString("video/x-h264,stream-format=byte-stream,alignment=au")
+		_ = e2eeVideoSrc.SetProperty("caps", e2eeCaps)
+
+		e2eeH264Parse, err = gst.NewElement("h264parse")
+		if err != nil {
+			return nil, fmt.Errorf("create e2ee h264parse: %w", err)
+		}
+		_ = e2eeH264Parse.SetProperty("disable-passthrough", true)
+		_ = e2eeH264Parse.SetProperty("config-interval", int32(-1))
+
+		e2eeVideoCapsFilter, err = gst.NewElement("capsfilter")
+		if err != nil {
+			return nil, fmt.Errorf("create e2ee video capsfilter: %w", err)
+		}
+		e2eeVideoCapsValue := gst.NewCapsFromString("video/x-h264,stream-format=byte-stream,alignment=au")
+		_ = e2eeVideoCapsFilter.SetProperty("caps", e2eeVideoCapsValue)
+
+		e2eeVideoQueue, err = gst.NewElement("queue")
+		if err != nil {
+			return nil, fmt.Errorf("create e2ee video queue: %w", err)
+		}
+		_ = e2eeVideoQueue.SetProperty("max-size-buffers", uint(0))
+		_ = e2eeVideoQueue.SetProperty("max-size-bytes", uint(0))
+		_ = e2eeVideoQueue.SetProperty("max-size-time", uint64(0))
+	}
 
 	audioSrc, err := gst.NewElement("appsrc")
 	if err != nil {
@@ -335,6 +385,12 @@ func NewParticipantRecorder(cfg *Config, roomName, participant string) (*Partici
 		videoSrc, videoJitter, videoDepay, h264parse, videoCapsFilter, videoQueue,
 		audioSrc, audioJitter, audioDepay,
 	}
+
+	// Add E2EE video path elements only when E2EE is enabled
+	if e2eeEnabled {
+		elements = append(elements, e2eeVideoSrc, e2eeH264Parse, e2eeVideoCapsFilter, e2eeVideoQueue)
+	}
+
 	if cfg.KeepOpus {
 		elements = append(elements, opusParse)
 	} else {
@@ -355,6 +411,13 @@ func NewParticipantRecorder(cfg *Config, roomName, participant string) (*Partici
 
 	if err := gst.ElementLinkMany(videoSrc, videoJitter, videoDepay, h264parse, videoCapsFilter, videoQueue); err != nil {
 		return nil, fmt.Errorf("failed to link video chain: %w", err)
+	}
+
+	// Link E2EE video pipeline (raw H264 path) only when E2EE is enabled
+	if e2eeEnabled {
+		if err := gst.ElementLinkMany(e2eeVideoSrc, e2eeH264Parse, e2eeVideoCapsFilter, e2eeVideoQueue); err != nil {
+			return nil, fmt.Errorf("link e2ee video chain: %w", err)
+		}
 	}
 
 	// Link audio pipeline based on codec configuration
@@ -379,6 +442,21 @@ func NewParticipantRecorder(cfg *Config, roomName, participant string) (*Partici
 	}
 	if linkRet := videoQueueSrc.Link(videoMuxPad); linkRet != gst.PadLinkOK {
 		return nil, fmt.Errorf("failed to link video queue to mux: %s", linkRet.String())
+	}
+
+	// Link E2EE video queue to muxer only when E2EE is enabled
+	if e2eeEnabled {
+		e2eeVideoMuxPad := mpegtsmux.GetRequestPad("sink_%d")
+		if e2eeVideoMuxPad == nil {
+			return nil, fmt.Errorf("get request pad from mpegtsmux for e2ee video")
+		}
+		e2eeVideoQueueSrc := e2eeVideoQueue.GetStaticPad("src")
+		if e2eeVideoQueueSrc == nil {
+			return nil, fmt.Errorf("get src pad from e2ee video queue")
+		}
+		if linkRet := e2eeVideoQueueSrc.Link(e2eeVideoMuxPad); linkRet != gst.PadLinkOK {
+			return nil, fmt.Errorf("link e2ee video queue to mux: %s", linkRet.String())
+		}
 	}
 
 	audioMuxPad := mpegtsmux.GetRequestPad("sink_%d")
@@ -419,18 +497,26 @@ func NewParticipantRecorder(cfg *Config, roomName, participant string) (*Partici
 	_ = os.Setenv("GST_DEBUG_DUMP_DOT_DIR", absDir)
 
 	recorder := &ParticipantRecorder{
-		participant:  participant,
-		room:         roomName,
-		outputDir:    absDir,
-		keepOpus:     cfg.KeepOpus,
-		pipeline:     pipeline,
-		videoAppSrc:  app.SrcFromElement(videoSrc),
-		audioAppSrc:  app.SrcFromElement(audioSrc),
-		videoDepay:   videoDepay,
-		audioDepay:   audioDepay,
-		startTime:    time.Now(),
-		videoReadyCh: make(chan struct{}),
-		s3Uploader:   s3Uploader,
+		logger:         logger,
+		participant:    participant,
+		room:           roomName,
+		outputDir:      absDir,
+		keepOpus:       cfg.KeepOpus,
+		pipeline:       pipeline,
+		videoAppSrc:    app.SrcFromElement(videoSrc),
+		audioAppSrc:    app.SrcFromElement(audioSrc),
+		videoDepay:     videoDepay,
+		audioDepay:     audioDepay,
+		startTime:      time.Now(),
+		videoReadyCh:   make(chan struct{}),
+		s3Uploader:     s3Uploader,
+		frameAssembler: NewFrameAssembler(),
+		e2eeVideoQueue: e2eeVideoQueue, // nil if E2EE disabled
+	}
+
+	// Set E2EE video appsrc only when E2EE is enabled
+	if e2eeEnabled && e2eeVideoSrc != nil {
+		recorder.e2eeVideoAppSrc = app.SrcFromElement(e2eeVideoSrc)
 	}
 
 	audioCodec := "AAC"
@@ -978,6 +1064,39 @@ func (r *ParticipantRecorder) clearPreAudioBuffer() {
 	r.preAudioMu.Unlock()
 }
 
+// pushE2EEVideoFrame pushes a decrypted H264 frame in Annex B format to the E2EE video appsrc.
+//
+// This function is used for E2EE video when we have complete decrypted frames
+// rather than individual RTP packets. The frame data is in Annex B format
+// (with start codes) and can be pushed directly to h264parse.
+//
+// Parameters:
+//   - frameData: Decrypted H264 frame in Annex B format
+//   - timestamp: RTP timestamp (32-bit, 90kHz clock)
+//
+// Returns:
+//   - nil on success
+//   - error if appsrc rejects the buffer
+func (r *ParticipantRecorder) pushE2EEVideoFrame(frameData []byte, timestamp uint32) error {
+	pts, relative := r.videoClockTime(timestamp)
+
+	buffer := gst.NewBufferFromBytes(frameData)
+	buffer.SetPresentationTimestamp(pts)
+
+	r.mu.Lock()
+	r.videoLastPTS = pts
+	r.videoLastTimestamp = relative
+	r.mu.Unlock()
+
+	if flow := r.e2eeVideoAppSrc.PushBuffer(buffer); flow != gst.FlowOK {
+		if flow == gst.FlowFlushing {
+			return fmt.Errorf("e2ee video appsrc flushing")
+		}
+		return fmt.Errorf("e2ee video appsrc push failed: %s", flow.String())
+	}
+	return nil
+}
+
 // pushVideoPacket converts an RTP packet to a GStreamer buffer and pushes it to the video appsrc.
 //
 // This function performs four critical operations:
@@ -1396,23 +1515,124 @@ func (r *ParticipantRecorder) AttachVideoTrack(ctx context.Context, track *webrt
 					return
 				}
 
-				// Decrypt E2EE-encrypted payload if E2EE is enabled
+				// For E2EE, use frame-level decryption instead of per-packet
+				// E2EE encryption happens at the frame level in Annex B format
+				// We need to collect RTP packets, reassemble to Annex B, decrypt, then push raw H264
 				if r.E2EEEnabled() && len(rtpPacket.Payload) > 0 {
+					// Add packet to frame assembler - it will return complete Annex B frame when ready
+					annexBFrame, frameTimestamp, complete := r.frameAssembler.AddPacket(rtpPacket)
+					if !complete {
+						// Frame not complete yet, wait for more packets
+						if firstPacket {
+							firstPacket = false
+							r.logger.Debug("E2EE: Requesting initial keyframe via PLI")
+							r.requestPLI(pliWriter, track.SSRC())
+						}
+						// Request PLI periodically while waiting for frames
+						if !r.handshakeReady.Load() {
+							handshakeWait++
+							if handshakeWait%200 == 0 {
+								r.logger.Debug("E2EE: Waiting for complete frame, sending PLI")
+								r.requestPLI(pliWriter, track.SSRC())
+							}
+						}
+						continue
+					}
+
+					// Frame is complete - decrypt it
 					r.mu.Lock()
 					e2eeCtx := r.e2eeCtx
 					r.mu.Unlock()
 
-					decrypted, err := e2eeCtx.DecryptVideo(rtpPacket.Payload)
-					if err != nil {
-						// Decryption failed - log and skip packet
-						log.Printf("[%s] video E2EE decryption error (seq=%d): %v", r.logPrefix(), rtpPacket.SequenceNumber, err)
+					decryptedFrame, decryptErr := e2eeCtx.DecryptVideoFrame(annexBFrame)
+					if decryptErr != nil {
+						log.Printf("[%s] video E2EE frame decryption error (ts=%d, frameSize=%d): %v",
+							r.logPrefix(), frameTimestamp, len(annexBFrame), decryptErr)
 						continue
 					}
-					if decrypted == nil {
+					if decryptedFrame == nil {
 						// Server Injected Frame - drop it
 						continue
 					}
-					rtpPacket.Payload = decrypted
+
+					// Check if this decrypted frame contains a keyframe
+					e2eeIsKeyframe := false
+					naluIndices := findNALUIndices(decryptedFrame)
+					for _, idx := range naluIndices {
+						if idx < len(decryptedFrame) {
+							nalType := decryptedFrame[idx] & 0x1F
+							if nalType == nalUnitTypeIDR {
+								e2eeIsKeyframe = true
+								break
+							}
+						}
+					}
+
+					// Signal handshake ready on first keyframe
+					if !r.handshakeReady.Load() {
+						if e2eeIsKeyframe {
+							r.mu.Lock()
+							r.videoKeyframeCount++
+							r.mu.Unlock()
+							r.signalVideoReady()
+							r.logger.Info("E2EE: Decrypted first keyframe (handshake ready)",
+								"ts", frameTimestamp, "frameSize", len(decryptedFrame))
+						} else {
+							handshakeWait++
+							if handshakeWait == 1 || handshakeWait%200 == 0 {
+								r.logger.Debug("E2EE: Waiting for keyframe, sending PLI")
+								r.requestPLI(pliWriter, track.SSRC())
+							}
+							continue
+						}
+					}
+
+					// Wait for recording activation
+					if !r.recordingActive.Load() {
+						continue
+					}
+
+					// Wait for keyframe to start recording
+					if r.recordingKeyframePending.Load() {
+						if !e2eeIsKeyframe {
+							recordingWait++
+							if recordingWait == 1 || recordingWait%200 == 0 {
+								r.logger.Debug("E2EE: Waiting for keyframe to begin recording, sending PLI")
+								r.requestPLI(pliWriter, track.SSRC())
+							}
+							continue
+						}
+
+						r.mu.Lock()
+						r.videoKeyframeCount++
+						r.mu.Unlock()
+
+						// Start pipeline on first recording keyframe
+						if !r.pipelineStarted.Load() {
+							r.logger.Info("E2EE: Starting GStreamer pipeline with first decrypted keyframe")
+							if startErr := r.pipeline.SetState(gst.StatePlaying); startErr != nil {
+								r.logger.Error("E2EE: start pipeline", "error", startErr)
+								return
+							}
+							r.pipeline.DebugBinToDotFileWithTs(gst.DebugGraphShowAll, "publisher_recorder_e2ee")
+							r.pipelineStarted.Store(true)
+						}
+
+						r.recordingKeyframePending.Store(false)
+					}
+
+					// Push decrypted frame to E2EE video appsrc
+					if pushErr := r.pushE2EEVideoFrame(decryptedFrame, frameTimestamp); pushErr != nil {
+						r.logger.Error("E2EE video push error", "error", pushErr)
+						return
+					}
+
+					r.mu.Lock()
+					r.videoPacketCount++
+					r.videoBytesReceived += int64(len(decryptedFrame))
+					r.mu.Unlock()
+
+					continue // Skip normal RTP processing for E2EE
 				}
 
 				if firstPacket {


### PR DESCRIPTION
Implement proper frame-level decryption that matches LiveKit JS SDK:
- Add FrameAssembler to collect RTP packets into complete H264 Annex B frames
- Support Single NAL, STAP-A, and FU-A packet types in frame assembly
- Add RBSP unescaping for emulation prevention bytes (0x00 0x00 0x03)
- Use base64 key decoding with HKDF derivation (matching client SDK)
- Create separate GStreamer pipeline path for decrypted E2EE video
- Add comprehensive tests for frame assembly and decryption